### PR TITLE
Put travis on current node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - 0.12
   - 4
   - 5
+  - 6
+  - 7
 
 script:
   - npm test


### PR DESCRIPTION
Hi again :)

This enable travis to work on current version of node, aka node 6 & node 7.

Right now, tests are green on this versions of node.

I also think that node 0.10 & node 5 can be removed as per the documentation (https://github.com/nodejs/LTS), neither of them are in an active state (current, LTS or maintenance).

Let me know what you think of this.